### PR TITLE
User Agent for image factor (closes #64).

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -295,7 +295,7 @@ func ImageFileFromContext(c *gin.Context, async bool, load bool) (*image.ImageFi
 		// Image not found from the KVStore, we need to process it
 		// URL available in Query String
 		if exists {
-			file, err = image.FromURL(u.(*url.URL))
+			file, err = image.FromURL(u.(*url.URL), cfg.Options.DefaultUserAgent)
 		} else {
 			// URL provided we use http protocol to retrieve it
 			s := storage.SourceFromContext(c)

--- a/config/config.go
+++ b/config/config.go
@@ -8,8 +8,8 @@ import (
 
 // Shard is a struct to allow shard location when files are uploaded
 type Shard struct {
-	Depth int
-	Width int
+	Depth    int
+	Width    int
 	RestOnly bool
 }
 
@@ -21,12 +21,13 @@ type AllowedSize struct {
 
 // Options is a struct to add options to the application
 type Options struct {
-	EnableUpload  bool `mapstructure:"enable_upload"`
-	EnableDelete  bool `mapstructure:"enable_delete"`
-	DefaultFormat string
-	Format        string
-	Quality       int
-	AllowedSizes  []AllowedSize `mapstructure:"allowed_sizes"`
+	EnableUpload     bool `mapstructure:"enable_upload"`
+	EnableDelete     bool `mapstructure:"enable_delete"`
+	DefaultFormat    string
+	Format           string
+	Quality          int
+	AllowedSizes     []AllowedSize `mapstructure:"allowed_sizes"`
+	DefaultUserAgent string        `mapstructure:"default_user_agent"`
 }
 
 // KVStore is a struct to represent a key/value store (redis, cache)
@@ -83,19 +84,20 @@ type Config struct {
 func DefaultConfig() *Config {
 	return &Config{
 		Options: &Options{
-			EnableDelete:  false,
-			EnableUpload:  false,
-			DefaultFormat: DefaultFormat,
-			Quality:       DefaultQuality,
-			Format:        "",
+			EnableDelete:     false,
+			EnableUpload:     false,
+			DefaultFormat:    DefaultFormat,
+			Quality:          DefaultQuality,
+			Format:           "",
+			DefaultUserAgent: DefaultUserAgent,
 		},
 		Port: DefaultPort,
 		KVStore: &KVStore{
 			Type: "dummy",
 		},
 		Shard: &Shard{
-			Width: DefaultShardWidth,
-			Depth: DefaultShardDepth,
+			Width:    DefaultShardWidth,
+			Depth:    DefaultShardDepth,
 			RestOnly: DefaultShardRestOnly,
 		},
 	}

--- a/config/constants.go
+++ b/config/constants.go
@@ -6,6 +6,9 @@ const DefaultFormat = "png"
 // DefaultQuality is the default quality for processed images
 const DefaultQuality = 95
 
+// DefaultUserAgent is the default user-agent header to fetch images from URL with
+const DefaultUserAgent = ""
+
 // DefaultPort is the default port of the application server
 const DefaultPort = 3001
 

--- a/image/factory.go
+++ b/image/factory.go
@@ -9,8 +9,8 @@ import (
 )
 
 // FromURL retrieves an ImageFile from an url
-func FromURL(u *url.URL) (*ImageFile, error) {
-	storage := &storage.HTTPStorage{}
+func FromURL(u *url.URL, userAgent string) (*ImageFile, error) {
+	storage := &storage.HTTPStorage{UserAgent: userAgent}
 
 	content, err := storage.OpenFromURL(u)
 

--- a/storage/http.go
+++ b/storage/http.go
@@ -15,6 +15,7 @@ import (
 // HTTPStorage wraps a storage
 type HTTPStorage struct {
 	gostorages.Storage
+	UserAgent string
 }
 
 // HeaderKeys represents the list of headers
@@ -45,7 +46,10 @@ func (s *HTTPStorage) Open(filepath string) (gostorages.File, error) {
 
 // OpenFromURL retrieves bytes from an url
 func (s *HTTPStorage) OpenFromURL(u *url.URL) ([]byte, error) {
-	content, err := goreq.Request{Uri: u.String()}.Do()
+	content, err := goreq.Request{
+		Uri:       u.String(),
+		UserAgent: s.UserAgent,
+	}.Do()
 
 	if err != nil {
 		return nil, err
@@ -69,8 +73,9 @@ func (s *HTTPStorage) HeadersFromURL(u *url.URL) (map[string]string, error) {
 	var headers = make(map[string]string)
 
 	content, err := goreq.Request{
-		Uri:    u.String(),
-		Method: "GET",
+		Uri:       u.String(),
+		Method:    "GET",
+		UserAgent: s.UserAgent,
 	}.Do()
 
 	if err != nil {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -62,7 +62,7 @@ func NewStorageFromConfig(cfg *config.Storage) (gostorages.Storage, error) {
 			return nil, err
 		}
 
-		return &HTTPStorage{storage}, nil
+		return &HTTPStorage{storage, ""}, nil
 	case "s3":
 		acl, ok := gostorages.ACLs[cfg.ACL]
 
@@ -96,7 +96,7 @@ func NewStorageFromConfig(cfg *config.Storage) (gostorages.Storage, error) {
 			return nil, err
 		}
 
-		return &HTTPStorage{storage}, nil
+		return &HTTPStorage{storage, ""}, nil
 	}
 
 	return nil, fmt.Errorf("storage %s does not exist", cfg.Type)


### PR DESCRIPTION
`DefaultUserAgent` leaving room for overrides in future.
Options section of config seemed most logical place for `DefaultUserAgent`.
`HTTPStorage.UserAgent` property added to save passing user-agent around for every function.
`HTTPStorage` can be used when creating `http` `Src`and `Dst` storages, but as not involved in image factory `DefaultUserAgent` is not set.